### PR TITLE
fix: remove duplicate JSON.parse in admin token handling

### DIFF
--- a/src/services/apiClient.ts
+++ b/src/services/apiClient.ts
@@ -178,7 +178,7 @@ const addAuthToken = (config: any) => {
             const parsedState = JSON.parse(reduxState);
             const authState = JSON.parse(parsedState.auth || '{}');
             if (authState.token) {
-                token = JSON.parse(authState.token);
+                token = authState.token;
             }
         }
     } catch (e) {


### PR DESCRIPTION
- Fixes 401 error for admin users accessing protected routes
- Removes unnecessary JSON.parse() on already parsed token
- Maintains compatibility with all user types