### PR TITLE
fix: Improve withdrawal modal UX with Stripe setup error handling

### DIFF
--- a/src/components/creator/BalanceAndWithdrawals.tsx
+++ b/src/components/creator/BalanceAndWithdrawals.tsx
@@ -51,7 +51,11 @@ interface WithdrawalModalBalance {
   }>;
 }
 
-export default function BalanceAndWithdrawals() {
+interface BalanceAndWithdrawalsProps {
+  setComponent?: (component: string) => void;
+}
+
+export default function BalanceAndWithdrawals({ setComponent }: BalanceAndWithdrawalsProps) {
   const [showWithdrawalModal, setShowWithdrawalModal] = useState(false);
   const [balance, setBalance] = useState<CreatorBalanceType | null>(null);
   const [loading, setLoading] = useState(true);
@@ -330,6 +334,7 @@ export default function BalanceAndWithdrawals() {
           onClose={() => setShowWithdrawalModal(false)}
           balance={transformedBalance}
           onWithdrawalCreated={handleWithdrawalCreated}
+          setComponent={setComponent}
         />
       )}
     </div>

--- a/src/components/creator/CreatorProfile.tsx
+++ b/src/components/creator/CreatorProfile.tsx
@@ -832,6 +832,7 @@ const handleRefreshProfile = useCallback(async () => {
           onClose={() => setShowWithdrawalModal(false)}
           balance={balance}
           onWithdrawalCreated={handleWithdrawalCreated}
+          setComponent={undefined}
         />
       )}
 

--- a/src/components/creator/WithdrawalModal.tsx
+++ b/src/components/creator/WithdrawalModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useEffect } from "react";
+import { useNavigate } from "react-router-dom";
 import {
   Dialog,
   DialogContent,
@@ -98,6 +99,7 @@ interface WithdrawalModalProps {
   onClose: () => void;
   balance: CreatorBalance;
   onWithdrawalCreated: () => void;
+  setComponent?: (component: string) => void;
 }
 
 export default function WithdrawalModal({
@@ -105,7 +107,9 @@ export default function WithdrawalModal({
   onClose,
   balance,
   onWithdrawalCreated,
+  setComponent,
 }: WithdrawalModalProps) {
+  const navigate = useNavigate();
   const [withdrawalMethods, setWithdrawalMethods] = useState<
     WithdrawalMethod[]
   >([]);
@@ -116,6 +120,7 @@ export default function WithdrawalModal({
   const [withdrawalDetails, setWithdrawalDetails] = useState<
     Record<string, string>
   >({});
+  const [countdown, setCountdown] = useState<number | null>(null);
   const { toast } = useToast();
   const { user, profile } = useAppSelector((state) => state.auth);
   const userData = profile || user;
@@ -265,25 +270,43 @@ export default function WithdrawalModal({
     } catch (error: any) {
       console.error("Error creating withdrawal:", error);
       
-      // Enhanced error toast with helpful guidance
-      const errorMessage = error.response?.data?.message || "Erro ao solicitar saque";
-      let helpfulMessage = errorMessage;
+      const errorData = error.response?.data || {};
+      const errorMessage = errorData.message || "Erro ao solicitar saque";
+      const actionRequired = errorData.action_required;
+      const blocked = errorData.blocked;
       
-      if (errorMessage.includes("Saldo insuficiente")) {
-        helpfulMessage = "Seu saldo disponível não é suficiente para este saque. Verifique seu saldo e tente novamente.";
-      } else if (errorMessage.includes("muitos saques pendentes")) {
-        helpfulMessage = "Você tem muitos saques pendentes. Aguarde o processamento dos saques atuais antes de solicitar um novo.";
-      } else if (errorMessage.includes("Valor deve estar entre")) {
-        helpfulMessage = errorMessage;
+      // Check if Stripe setup is required
+      if (actionRequired === "stripe_setup" && blocked) {
+        // Start countdown
+        setCountdown(5);
+        
+        // Show error toast with countdown
+        toast({
+          title: "⚠️ Configuração Stripe Necessária",
+          description: errorMessage,
+          variant: "destructive",
+          duration: 6000,
+        });
+      } else {
+        // Enhanced error toast with helpful guidance for other errors
+        let helpfulMessage = errorMessage;
+        
+        if (errorMessage.includes("Saldo insuficiente")) {
+          helpfulMessage = "Seu saldo disponível não é suficiente para este saque. Verifique seu saldo e tente novamente.";
+        } else if (errorMessage.includes("muitos saques pendentes")) {
+          helpfulMessage = "Você tem muitos saques pendentes. Aguarde o processamento dos saques atuais antes de solicitar um novo.";
+        } else if (errorMessage.includes("Valor deve estar entre")) {
+          helpfulMessage = errorMessage;
+        }
+        
+        toast({
+          title: "❌ Erro ao Solicitar Saque",
+          description: `${helpfulMessage}\n\n` +
+            `💡 Se o problema persistir, entre em contato com o suporte.`,
+          variant: "destructive",
+          duration: 6000,
+        });
       }
-      
-      toast({
-        title: "❌ Erro ao Solicitar Saque",
-        description: `${helpfulMessage}\n\n` +
-          `💡 Se o problema persistir, entre em contato com o suporte.`,
-        variant: "destructive",
-        duration: 6000,
-      });
     } finally {
       setIsLoading(false);
     }
@@ -293,7 +316,41 @@ export default function WithdrawalModal({
     setAmount("");
     setSelectedMethod("");
     setWithdrawalDetails({});
+    setCountdown(null);
   };
+
+  // Cleanup countdown on unmount or modal close
+  useEffect(() => {
+    if (!isOpen) {
+      setCountdown(null);
+    }
+  }, [isOpen]);
+
+  // Handle countdown and redirect
+  useEffect(() => {
+    if (countdown !== null && countdown > 0) {
+      const countdownInterval = setInterval(() => {
+        setCountdown((prev) => {
+          if (prev === null || prev <= 1) {
+            // Close modal first
+            onClose();
+            // Navigate to Stripe Connect page
+            setTimeout(() => {
+              if (setComponent) {
+                setComponent("Configuração Stripe");
+              } else {
+                navigate("/creator/stripe-connect");
+              }
+            }, 100);
+            return null;
+          }
+          return prev - 1;
+        });
+      }, 1000);
+
+      return () => clearInterval(countdownInterval);
+    }
+  }, [countdown, onClose, setComponent, navigate]);
 
   const handleClose = () => {
     if (!isLoading) {
@@ -641,9 +698,19 @@ export default function WithdrawalModal({
 
   return (
     <Dialog open={isOpen} onOpenChange={handleClose}>
-      <DialogContent className="sm:max-w-md max-h-[90vh] flex flex-col">
+      <DialogContent className="sm:max-w-md max-h-[90vh] flex flex-col z-[100]">
         <DialogHeader>
           <DialogTitle>Solicitar Saque</DialogTitle>
+          {countdown !== null && countdown > 0 && (
+            <div className="mt-2 p-3 bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800 rounded-lg">
+              <div className="flex items-center gap-2 text-red-800 dark:text-red-200">
+                <AlertTriangle className="h-4 w-4" />
+                <span className="text-sm font-medium">
+                  Redirecionando para configuração do Stripe em {countdown} segundo{countdown !== 1 ? 's' : ''}...
+                </span>
+              </div>
+            </div>
+          )}
         </DialogHeader>
 
         <div className="mt-2 p-3 bg-amber-50 border border-amber-200 rounded-lg mx-6">

--- a/src/components/ui/dialog.tsx
+++ b/src/components/ui/dialog.tsx
@@ -19,7 +19,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      "fixed inset-0 z-[100] bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
       className
     )}
     {...props}
@@ -36,7 +36,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        "fixed left-[50%] top-[50%] z-[101] grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
         className
       )}
       {...props}

--- a/src/pages/creator/Index.tsx
+++ b/src/pages/creator/Index.tsx
@@ -124,7 +124,7 @@ function Index() {
             case "Portfólio":
                 return <Portfolio />;
             case "Saldo e Saques":
-                return <BalanceAndWithdrawals />;
+                return <BalanceAndWithdrawals setComponent={handleComponentChange} />;
             case "Notificações":
                 return <Notification />;
             case "Assinatura":


### PR DESCRIPTION
- Add countdown timer (5 seconds) when Stripe setup is required
- Show error message in modal header with countdown
- Auto-redirect to Stripe Connect configuration page after countdown
- Fix z-index issues (overlay z-100, content z-101) to prevent elements passing through modal
- Add setComponent prop support for navigation within creator dashboard
- Improve error handling for blocked withdrawals requiring Stripe setup