### PR TITLE
fix: corrigir imagens quebradas de logos de campanha

### DIFF
--- a/src/components/admin/CampaignDetail.tsx
+++ b/src/components/admin/CampaignDetail.tsx
@@ -14,6 +14,7 @@ import {
   CarouselPrevious,
 } from "../ui/carousel";
 import { File, FileText, Image, Download, ExternalLink } from "lucide-react";
+import { getCampaignLogoUrl } from "../../utils/imageUtils";
 
 const statesColors = [
   "bg-pink-100 text-pink-700 dark:bg-pink-900 dark:text-pink-200",
@@ -108,15 +109,28 @@ const CampaignDetail = ({
           {/* Header */}
           <div className="flex flex-col sm:flex-row items-center sm:items-start gap-4 border-b border-gray-200 dark:border-neutral-700 pb-4 mb-4">
             <div className="w-16 h-16 rounded-full bg-gradient-to-br from-pink-500 to-purple-600 flex items-center justify-center text-white font-bold text-lg overflow-hidden border">
-              {displayData.logo ? (
-                <img
-                  src={`${import.meta.env.VITE_BACKEND_URL || 'https://nexacreators.com.br'}${displayData.logo}`}
-                  alt={`${displayData.brand?.name || 'Campaign'} logo`}
-                  className="w-full h-full object-cover"
-                />
-              ) : (
-                displayData.brand?.name?.charAt(0)?.toUpperCase() || 'N'
-              )}
+              {(() => {
+                const logoUrl = getCampaignLogoUrl(displayData.logo);
+                if (logoUrl) {
+                  return (
+                    <img
+                      src={logoUrl}
+                      alt={`${displayData.brand?.name || 'Campaign'} logo`}
+                      className="w-full h-full object-cover"
+                      onError={(e) => {
+                        // Hide image and show initials on error
+                        const target = e.target as HTMLImageElement;
+                        target.style.display = 'none';
+                        const parent = target.parentElement;
+                        if (parent) {
+                          parent.textContent = displayData.brand?.name?.charAt(0)?.toUpperCase() || displayData.title?.charAt(0)?.toUpperCase() || 'N';
+                        }
+                      }}
+                    />
+                  );
+                }
+                return <span>{displayData.brand?.name?.charAt(0)?.toUpperCase() || displayData.title?.charAt(0)?.toUpperCase() || 'N'}</span>;
+              })()}
             </div>
             <div className="flex-1 text-center sm:text-left">
               <DialogTitle className="text-xl font-bold text-gray-900 dark:text-white">

--- a/src/components/brand/AllowedCampaigns.tsx
+++ b/src/components/brand/AllowedCampaigns.tsx
@@ -16,6 +16,7 @@ import {
 import { Skeleton } from "../ui/skeleton";
 import { Alert, AlertDescription } from "../ui/alert";
 import { AlertCircle, User, RefreshCw, DollarSign } from "lucide-react";
+import { getCampaignLogoUrl, getCampaignInitials } from "../../utils/imageUtils";
 
 const tagColors: Record<string, string> = {
     Photo: "bg-purple-100 text-purple-600 dark:bg-purple-900 dark:text-purple-200",
@@ -297,11 +298,30 @@ const AllowedCampaigns: React.FC<AllowedCampaignsProps> = ({ setComponent }) => 
                                 className="bg-background rounded-xl shadow-sm border border-mute p-5 flex flex-col gap-3 hover:shadow-md transition-shadow"
                             >
                                 <div className="flex items-center gap-3">
-                                    <img
-                                        src={`${import.meta.env.VITE_BACKEND_URL || 'https://nexacreators.com.br'}${campaign.logo}`}
-                                        alt="campaign"
-                                        className="w-12 h-12 rounded-full object-cover border border-zinc-200 dark:border-zinc-700"
-                                    />
+                                    <div className="w-12 h-12 rounded-full bg-gradient-to-br from-pink-500 to-purple-600 flex items-center justify-center text-white font-bold overflow-hidden border border-zinc-200 dark:border-zinc-700 flex-shrink-0">
+                                        {(() => {
+                                            const logoUrl = getCampaignLogoUrl(campaign.logo);
+                                            if (logoUrl) {
+                                                return (
+                                                    <img
+                                                        src={logoUrl}
+                                                        alt={campaign.title || "campaign"}
+                                                        className="w-full h-full object-cover"
+                                                        onError={(e) => {
+                                                            // Hide image and show initials on error
+                                                            const target = e.target as HTMLImageElement;
+                                                            target.style.display = 'none';
+                                                            const parent = target.parentElement;
+                                                            if (parent) {
+                                                                parent.textContent = getCampaignInitials(campaign.title);
+                                                            }
+                                                        }}
+                                                    />
+                                                );
+                                            }
+                                            return <span>{getCampaignInitials(campaign.title)}</span>;
+                                        })()}
+                                    </div>
                                     <div className="flex-1">
                                         <div className="font-semibold text-base md:text-lg text-black dark:text-white line-clamp-1">
                                             {campaign.title}

--- a/src/components/brand/CampaignManagement.tsx
+++ b/src/components/brand/CampaignManagement.tsx
@@ -28,6 +28,7 @@ import { ptBR } from "date-fns/locale";
 import EditCampaign from "./EditCampaign";
 import { hiringApi } from "../../api/hiring";
 import CampaignTimelineSidebar from "../CampaignTimelineSidebar";
+import { getCampaignLogoUrl } from "../../utils/imageUtils";
 
 interface CampaignManagementProps {
   setComponent?: (component: string | { name: string; campaign?: any }) => void;
@@ -322,16 +323,29 @@ const CampaignManagement: React.FC<CampaignManagementProps> = ({ setComponent })
                 {/* Campaign Info */}
                 <div className="flex-1">
                   <div className="flex items-start gap-4">
-                    <div className="w-16 h-16 rounded-lg border border-gray-200 dark:border-gray-700 flex items-center justify-center bg-gray-50 dark:bg-gray-700">
-                      {campaign.logo ? (
-                        <img
-                        src={`${import.meta.env.VITE_BACKEND_URL}${campaign.logo}`}
-                          alt={campaign.title}
-                          className="w-full h-full rounded-lg object-cover"
-                        />
-                      ) : (
-                        <FileText className="w-8 h-8 text-gray-400" />
-                      )}
+                    <div className="w-16 h-16 rounded-lg border border-gray-200 dark:border-gray-700 flex items-center justify-center bg-gray-50 dark:bg-gray-700 overflow-hidden">
+                      {(() => {
+                        const logoUrl = getCampaignLogoUrl(campaign.logo);
+                        if (logoUrl) {
+                          return (
+                            <img
+                              src={logoUrl}
+                              alt={campaign.title}
+                              className="w-full h-full rounded-lg object-cover"
+                              onError={(e) => {
+                                // Hide image and show fallback on error
+                                const target = e.target as HTMLImageElement;
+                                target.style.display = 'none';
+                                const parent = target.parentElement;
+                                if (parent) {
+                                  parent.innerHTML = '<svg class="w-8 h-8 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>';
+                                }
+                              }}
+                            />
+                          );
+                        }
+                        return <FileText className="w-8 h-8 text-gray-400" />;
+                      })()}
                     </div>
                     <div className="flex-1">
                       <div className="flex items-center gap-2 mb-2">
@@ -472,16 +486,29 @@ const CampaignManagement: React.FC<CampaignManagementProps> = ({ setComponent })
           <div className="bg-white dark:bg-[#0d0d0d] border rounded-xl shadow-xl p-6 w-full max-w-4xl max-h-[90vh] overflow-y-auto">
             <div className="flex justify-between items-start mb-6">
               <div className="flex items-start gap-4">
-                <div className="w-20 h-20 rounded-lg border border-gray-200 dark:border-gray-700 flex items-center justify-center bg-gray-50 dark:bg-gray-700">
-                  {selectedCampaign.logo ? (
-                    <img
-                      src={`${import.meta.env.VITE_BACKEND_URL}${selectedCampaign.logo}`}
-                      alt={selectedCampaign.title}
-                      className="w-full h-full rounded-lg object-cover"
-                    />
-                  ) : (
-                    <FileText className="w-10 h-10 text-gray-400" />
-                  )}
+                <div className="w-20 h-20 rounded-lg border border-gray-200 dark:border-gray-700 flex items-center justify-center bg-gray-50 dark:bg-gray-700 overflow-hidden">
+                  {(() => {
+                    const logoUrl = getCampaignLogoUrl(selectedCampaign.logo);
+                    if (logoUrl) {
+                      return (
+                        <img
+                          src={logoUrl}
+                          alt={selectedCampaign.title}
+                          className="w-full h-full rounded-lg object-cover"
+                          onError={(e) => {
+                            // Hide image and show fallback on error
+                            const target = e.target as HTMLImageElement;
+                            target.style.display = 'none';
+                            const parent = target.parentElement;
+                            if (parent) {
+                              parent.innerHTML = '<svg class="w-10 h-10 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z"></path></svg>';
+                            }
+                          }}
+                        />
+                      );
+                    }
+                    return <FileText className="w-10 h-10 text-gray-400" />;
+                  })()}
                 </div>
                 <div>
                   <h2 className="text-2xl font-bold text-gray-900 dark:text-white mb-2">

--- a/src/components/brand/ViewApplication.tsx
+++ b/src/components/brand/ViewApplication.tsx
@@ -3,6 +3,7 @@ import { useDispatch, useSelector } from "react-redux";
 import { AppDispatch, RootState } from "../../store";
 import { fetchCampaignById } from "../../store/thunks/campaignThunks";
 import { Campaign } from "../../store/slices/campaignSlice";
+import { getCampaignLogoUrl } from "../../utils/imageUtils";
 
 const labelClass =
   "text-xs font-medium text-gray-500 dark:text-gray-400 flex items-center gap-1";
@@ -264,24 +265,30 @@ const ViewApplication: React.FC<ViewApplicationProps> = ({ setComponent, campaig
         <div className="flex flex-col sm:flex-row items-center justify-between sm:items-start gap-4 border-b border-gray-200 dark:border-neutral-700 pb-4 mb-4">
           <div className="flex justify-center items-center gap-4">
             <div className="flex-shrink-0 w-16 h-16 rounded-full bg-gray-200 dark:bg-neutral-700 flex items-center justify-center text-3xl font-bold text-gray-400 overflow-hidden">
-              {campaign.logo ? (
-                <img
-                  src={`${import.meta.env.VITE_BACKEND_URL || 'https://nexacreators.com.br'}${campaign.logo}`}
-                  alt="Campaign Logo" 
-                  className="w-full h-full object-cover"
-                  style={{ 
-                    minWidth: 0, 
-                    minHeight: 0,
-                    objectFit: 'cover',
-                    maxWidth: '100%',
-                    maxHeight: '100%'
-                  }}
-                  onError={(e) => {
-                    e.currentTarget.style.display = 'none';
-                    e.currentTarget.nextElementSibling?.classList.remove('hidden');
-                  }}
-                />
-              ) : null}
+              {(() => {
+                const logoUrl = getCampaignLogoUrl(campaign.logo);
+                if (logoUrl) {
+                  return (
+                    <img
+                      src={logoUrl}
+                      alt="Campaign Logo" 
+                      className="w-full h-full object-cover"
+                      style={{ 
+                        minWidth: 0, 
+                        minHeight: 0,
+                        objectFit: 'cover',
+                        maxWidth: '100%',
+                        maxHeight: '100%'
+                      }}
+                      onError={(e) => {
+                        e.currentTarget.style.display = 'none';
+                        e.currentTarget.nextElementSibling?.classList.remove('hidden');
+                      }}
+                    />
+                  );
+                }
+                return null;
+              })()}
               <span className={`text-gray-400 ${campaign.logo ? 'hidden' : ''}`}>
                 {campaign.title ? campaign.title.charAt(0).toUpperCase() : '📷'}
               </span>

--- a/src/components/creator/CampaignCard.tsx
+++ b/src/components/creator/CampaignCard.tsx
@@ -5,6 +5,7 @@ import { Button } from "../ui/button";
 import { Avatar, AvatarFallback, AvatarImage } from "../ui/avatar";
 import { Separator } from "../ui/separator";
 import { Eye, Clock, MapPin, DollarSign, Calendar, Users, Heart, User, Star, RefreshCw } from "lucide-react";
+import { getCampaignLogoUrl } from "../../utils/imageUtils";
 
 interface CampaignCardProps {
     campaign: any;
@@ -126,16 +127,22 @@ const CampaignCard: React.FC<CampaignCardProps> = ({
                 <div className="flex items-start justify-between">
                     <div className="flex items-center gap-2 flex-1 min-w-0">
                         <Avatar className="h-8 w-8">
-                            {campaign.logo && campaign.logo.trim() !== '' ? (
-                                <AvatarImage 
-                                    src={`${import.meta.env.VITE_BACKEND_URL || 'http://localhost:8000'}${campaign.logo}`} 
-                                    alt={campaign.title}
-                                    onError={(e) => {
-                                        // Hide the image if it fails to load, fallback will show
-                                        e.currentTarget.style.display = 'none';
-                                    }}
-                                />
-                            ) : null}
+                            {(() => {
+                                const logoUrl = getCampaignLogoUrl(campaign.logo);
+                                if (logoUrl) {
+                                    return (
+                                        <AvatarImage 
+                                            src={logoUrl} 
+                                            alt={campaign.title}
+                                            onError={(e) => {
+                                                // Hide the image if it fails to load, fallback will show
+                                                e.currentTarget.style.display = 'none';
+                                            }}
+                                        />
+                                    );
+                                }
+                                return null;
+                            })()}
                             <AvatarFallback className="bg-gradient-to-br from-blue-500 to-purple-600 text-white font-semibold">
                                 {campaign.title?.charAt(0)?.toUpperCase() || 'C'}
                             </AvatarFallback>

--- a/src/components/creator/ProjectDetail.tsx
+++ b/src/components/creator/ProjectDetail.tsx
@@ -6,6 +6,7 @@ import { formatDate } from "date-fns";
 import { toast } from "../ui/sonner";
 import { fetchCreatorApplications } from "../../store/thunks/campaignThunks";
 import { fetchApprovedCampaigns, fetchCampaignById } from "../../store/thunks/campaignThunks";
+import { getCampaignLogoUrl } from "../../utils/imageUtils";
 import {
   Dialog,
   DialogContent,
@@ -168,32 +169,36 @@ const ProjectDetail: React.FC<ProjectDetailProps> = ({
             <div className="flex items-center gap-4 mb-8">
               {/* Campaign Logo */}
               <div className="flex-shrink-0">
-                {(project.logo || (project as any).logo_url) ? (
-                  <img
-                    src={`${import.meta.env.VITE_BACKEND_URL ||
-                      "https://nexacreators.com.br"
-                      }${project.logo || (project as any).logo_url || ''}`}
-                    alt={`${project.title} logo`}
-                    className="w-16 h-16 rounded-xl object-cover border border-border cursor-pointer hover:opacity-80 transition-opacity"
-                    style={{
-                      minWidth: 0,
-                      minHeight: 0,
-                      objectFit: 'cover',
-                      maxWidth: '100%',
-                      maxHeight: '100%'
-                    }}
-                    onClick={() => {
-                      const logoUrl = `${import.meta.env.VITE_BACKEND_URL || "https://nexacreators.com.br"}${project.logo || (project as any).logo_url || ''}`;
-                      setSelectedImageUrl(logoUrl);
-                      setImageModalOpen(true);
-                    }}
-                    onError={(e) => {
-                      const target = e.target as HTMLImageElement;
-                      target.style.display = "none";
-                      target.nextElementSibling?.classList.remove("hidden");
-                    }}
-                  />
-                ) : null}
+                {(() => {
+                  const logoPath = project.logo || (project as any).logo_url;
+                  const logoUrl = getCampaignLogoUrl(logoPath);
+                  if (logoUrl) {
+                    return (
+                      <img
+                        src={logoUrl}
+                        alt={`${project.title} logo`}
+                        className="w-16 h-16 rounded-xl object-cover border border-border cursor-pointer hover:opacity-80 transition-opacity"
+                        style={{
+                          minWidth: 0,
+                          minHeight: 0,
+                          objectFit: 'cover',
+                          maxWidth: '100%',
+                          maxHeight: '100%'
+                        }}
+                        onClick={() => {
+                          setSelectedImageUrl(logoUrl);
+                          setImageModalOpen(true);
+                        }}
+                        onError={(e) => {
+                          const target = e.target as HTMLImageElement;
+                          target.style.display = "none";
+                          target.nextElementSibling?.classList.remove("hidden");
+                        }}
+                      />
+                    );
+                  }
+                  return null;
+                })()}
                 {(!project.logo && !(project as any).logo_url) && (
                   <div className="w-16 h-16 rounded-xl border border-border flex items-center justify-center text-2xl font-bold text-white bg-gradient-to-br from-primary to-primary/80">
                     {project.title.charAt(0).toUpperCase()}

--- a/src/components/ui/CampaignLogo.tsx
+++ b/src/components/ui/CampaignLogo.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { getCampaignLogoUrl, getCampaignInitials } from "../../utils/imageUtils";
 
 interface CampaignLogoProps {
   logo?: string | null;
@@ -19,37 +20,13 @@ const CampaignLogo: React.FC<CampaignLogoProps> = ({
     lg: 'w-20 h-20 sm:w-24 sm:h-24 text-xl'
   };
 
-  const getLogoUrl = (logoPath: string) => {
-    // If it's already a full URL, return as is
-    if (logoPath.startsWith('http://') || logoPath.startsWith('https://')) {
-      return logoPath;
-    }
+  const logoUrl = getCampaignLogoUrl(logo);
 
-    const backendUrl = import.meta.env.VITE_BACKEND_URL || 'https://nexacreators.com.br';
-
-    // If it starts with /, it's a relative path from the backend
-    if (logoPath.startsWith('/')) {
-      return `${backendUrl}${logoPath}`;
-    }
-
-    // Otherwise, assume it's a relative path and prepend the backend URL
-    return `${backendUrl}/${logoPath}`;
-  };
-
-  const getInitials = (name: string) => {
-    return name
-      .split(' ')
-      .map(word => word.charAt(0))
-      .join('')
-      .toUpperCase()
-      .slice(0, 2);
-  };
-
-  if (logo) {
+  if (logoUrl) {
     return (
       <div className={`${sizeClasses[size]} rounded-full bg-gradient-to-br from-pink-500 to-purple-600 flex items-center justify-center text-white font-bold overflow-hidden ${className}`}>
         <img
-          src={getLogoUrl(logo)}
+          src={logoUrl}
           alt={`${brandName} logo`}
           className="w-full h-full object-cover"
           onError={(e) => {
@@ -58,7 +35,7 @@ const CampaignLogo: React.FC<CampaignLogoProps> = ({
             target.style.display = 'none';
             const parent = target.parentElement;
             if (parent) {
-              parent.textContent = getInitials(brandName);
+              parent.textContent = getCampaignInitials(brandName);
             }
           }}
         />
@@ -69,7 +46,7 @@ const CampaignLogo: React.FC<CampaignLogoProps> = ({
   // Fallback to brand initials
   return (
     <div className={`${sizeClasses[size]} rounded-full bg-gradient-to-br from-pink-500 to-purple-600 flex items-center justify-center text-white font-bold ${className}`}>
-      {getInitials(brandName)}
+      {getCampaignInitials(brandName)}
     </div>
   );
 };

--- a/src/utils/imageUtils.ts
+++ b/src/utils/imageUtils.ts
@@ -1,0 +1,73 @@
+/**
+ * Utility functions for handling image URLs, especially campaign logos
+ * Prevents broken images by validating URLs before rendering
+ */
+
+/**
+ * Validates if a logo path is valid (not null, undefined, or empty)
+ * 
+ * @param logo - Logo path from backend
+ * @returns true if logo is valid, false otherwise
+ */
+export const isValidLogo = (logo: string | null | undefined): boolean => {
+  return !!(logo && typeof logo === 'string' && logo.trim() !== '' && logo !== 'null');
+};
+
+/**
+ * Builds a complete URL for a campaign logo
+ * Returns null if logo is invalid to prevent broken images
+ * 
+ * @param logo - Logo path from backend (e.g., "/storage/campaigns/logos/file.jpg")
+ * @param backendUrl - Optional backend URL (defaults to env variable or production URL)
+ * @returns Complete URL or null if logo is invalid
+ */
+export const getCampaignLogoUrl = (
+  logo: string | null | undefined,
+  backendUrl?: string
+): string | null => {
+  // Validate logo first
+  if (!isValidLogo(logo)) {
+    return null;
+  }
+
+  const baseUrl = backendUrl || import.meta.env.VITE_BACKEND_URL || 'https://nexacreators.com.br';
+  
+  // If logo is already a full URL, return as is
+  if (logo.startsWith('http://') || logo.startsWith('https://')) {
+    return logo;
+  }
+
+  // If logo starts with /, it's a relative path from the backend
+  if (logo.startsWith('/')) {
+    return `${baseUrl}${logo}`;
+  }
+
+  // Otherwise, assume it's a relative path and prepend the backend URL
+  return `${baseUrl}/${logo}`;
+};
+
+/**
+ * Gets campaign initials for fallback display
+ * 
+ * @param title - Campaign title
+ * @returns First letter(s) of the title in uppercase
+ */
+export const getCampaignInitials = (title: string | null | undefined): string => {
+  if (!title || typeof title !== 'string') {
+    return '📷';
+  }
+  
+  const words = title.trim().split(/\s+/);
+  if (words.length === 0) {
+    return '📷';
+  }
+  
+  // Get first letter of first word, or first two letters if single word
+  if (words.length === 1) {
+    return words[0].charAt(0).toUpperCase() || '📷';
+  }
+  
+  // Get first letter of first two words
+  return (words[0].charAt(0) + words[1].charAt(0)).toUpperCase();
+};
+


### PR DESCRIPTION
- Criar função utilitária imageUtils.ts para validar e formatar URLs de logos
- Validar logo antes de renderizar imagem em todos os componentes
- Adicionar tratamento de erro onError em todas as imagens de logo
- Adicionar fallbacks visuais (iniciais ou ícones) quando logo não existe
- Prevenir URLs quebradas como 'https://nexacreators.com.brnull'

Componentes corrigidos:
- AllowedCampaigns.tsx
- CampaignManagement.tsx (2 locais)
- CampaignDetail.tsx
- ViewApplication.tsx
- ProjectDetail.tsx
- CampaignCard.tsx
- CampaignLogo.tsx

Isso resolve o problema onde imagens apareciam quebradas quando campaign.logo era null